### PR TITLE
Confirm email feature

### DIFF
--- a/packages/backend-test-helper/.eslintrc.cjs
+++ b/packages/backend-test-helper/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: { node: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-explicit-any': 'warn',
+  },
+}

--- a/packages/backend-test-helper/src/index.ts
+++ b/packages/backend-test-helper/src/index.ts
@@ -1,6 +1,6 @@
-export * from './job-trigger.js';
+export * from './job-trigger';
 
-import { JobTrigger } from './job-trigger.js';
+import { JobTrigger } from './job-trigger';
 
 let globalJobTrigger: JobTrigger | null = null;
 

--- a/packages/backend/.eslintrc.cjs
+++ b/packages/backend/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: { node: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-explicit-any': 'warn',
+  },
+}

--- a/packages/backend/src/config/passport.ts
+++ b/packages/backend/src/config/passport.ts
@@ -1,8 +1,8 @@
 import passport from 'passport';
 import { Strategy as LocalStrategy } from 'passport-local';
 import bcrypt from 'bcrypt';
-import { getDataSource } from '../database/index.js';
-import { UserEntity } from '../database/entities/User.js';
+import { getDataSource } from '../database/index';
+import { UserEntity } from '../database/entities/User';
 
 export const configurePassport = () => {
   passport.use(new LocalStrategy(

--- a/packages/backend/src/database/entities/EmailConfirmation.ts
+++ b/packages/backend/src/database/entities/EmailConfirmation.ts
@@ -1,0 +1,37 @@
+import { 
+  Entity, 
+  PrimaryGeneratedColumn, 
+  Column, 
+  CreateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn
+} from 'typeorm';
+import { UserEntity } from './User.js';
+
+@Entity('email_confirmations')
+@Index(['userId', 'code'])
+@Index(['expiresAt'])
+export class EmailConfirmationEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  userId!: string;
+
+  @ManyToOne(() => UserEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user!: UserEntity;
+
+  @Column({ type: 'varchar', length: 6 })
+  code!: string;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt!: Date;
+
+  @Column({ type: 'boolean', default: false })
+  used!: boolean;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/packages/backend/src/database/entities/EmailConfirmation.ts
+++ b/packages/backend/src/database/entities/EmailConfirmation.ts
@@ -7,7 +7,7 @@ import {
   ManyToOne,
   JoinColumn
 } from 'typeorm';
-import { UserEntity } from './User.js';
+import { UserEntity } from './User';
 
 @Entity('email_confirmations')
 @Index(['userId', 'code'])

--- a/packages/backend/src/database/index.ts
+++ b/packages/backend/src/database/index.ts
@@ -1,7 +1,7 @@
 import { DataSource } from 'typeorm';
 import { DatabaseManager, createDataSource as createSharedDataSource } from 'shared-backend/database';
-import { UserEntity } from './entities/User.js';
-import { EmailConfirmationEntity } from './entities/EmailConfirmation.js';
+import { UserEntity } from './entities/User';
+import { EmailConfirmationEntity } from './entities/EmailConfirmation';
 
 // Create a singleton database manager for the backend
 const dbManager = new DatabaseManager({

--- a/packages/backend/src/database/index.ts
+++ b/packages/backend/src/database/index.ts
@@ -1,10 +1,11 @@
 import { DataSource } from 'typeorm';
 import { DatabaseManager, createDataSource as createSharedDataSource } from 'shared-backend/database';
 import { UserEntity } from './entities/User.js';
+import { EmailConfirmationEntity } from './entities/EmailConfirmation.js';
 
 // Create a singleton database manager for the backend
 const dbManager = new DatabaseManager({
-  entities: [UserEntity],
+  entities: [UserEntity, EmailConfirmationEntity],
   migrations: [],
   synchronize: false, // Always use migrations in production
 });
@@ -12,7 +13,7 @@ const dbManager = new DatabaseManager({
 // Legacy compatibility functions
 export const createDataSource = () => {
   return createSharedDataSource({
-    entities: [UserEntity],
+    entities: [UserEntity, EmailConfirmationEntity],
     migrations: [],
     synchronize: false,
   });

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -2,12 +2,12 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
-import { config } from './config/index.js';
-import { initializeDatabase } from './database/index.js';
-import { authRoutes } from './routes/auth.js';
-import { userRoutes } from './routes/users.js';
-import { trackerRoutes } from './routes/trackers.js';
-import { errorHandler } from './middleware/errorHandler.js';
+import { config } from './config/index';
+import { initializeDatabase } from './database/index';
+import { authRoutes } from './routes/auth';
+import { userRoutes } from './routes/users';
+import { trackerRoutes } from './routes/trackers';
+import { errorHandler } from './middleware/errorHandler';
 
 async function createApp() {
   const app = express();

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -1,9 +1,9 @@
 import jwt from 'jsonwebtoken';
 import type { Request, Response, NextFunction } from 'express';
 import type { User } from 'shared-types';
-import { config } from '../config/index.js';
-import { getDataSource } from '../database/index.js';
-import { UserEntity, UserRole } from '../database/entities/User.js';
+import { config } from '../config/index';
+import { getDataSource } from '../database/index';
+import { UserEntity, UserRole } from '../database/entities/User';
 
 export interface AuthenticatedRequest extends Request {
   user?: User;

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -4,12 +4,12 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import PgBoss from 'pg-boss';
 import type { CreateUserRequest, LoginRequest, AuthResponse, ApiResponse, User } from 'shared-types';
-import { config } from '../config/index.js';
-import { getDataSource } from '../database/index.js';
-import { UserEntity, UserRole } from '../database/entities/User.js';
-import { EmailConfirmationEntity } from '../database/entities/EmailConfirmation.js';
-import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth.js';
-import { EmailConfirmationService } from '../services/email-confirmation.js';
+import { config } from '../config/index';
+import { getDataSource } from '../database/index';
+import { UserEntity, UserRole } from '../database/entities/User';
+import { EmailConfirmationEntity } from '../database/entities/EmailConfirmation';
+import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth';
+import { EmailConfirmationService } from '../services/email-confirmation';
 import { getDatabaseUrl } from 'shared-backend/config';
 
 const router = Router();

--- a/packages/backend/src/routes/users.ts
+++ b/packages/backend/src/routes/users.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import type { User, ApiResponse } from 'shared-types';
-import { getDataSource } from '../database/index.js';
-import { UserEntity, UserRole } from '../database/entities/User.js';
-import { authenticateToken, requireAdmin, type AuthenticatedRequest } from '../middleware/auth.js';
+import { getDataSource } from '../database/index';
+import { UserEntity, UserRole } from '../database/entities/User';
+import { authenticateToken, requireAdmin, type AuthenticatedRequest } from '../middleware/auth';
 
 const router = Router();
 

--- a/packages/backend/src/services/email-confirmation.ts
+++ b/packages/backend/src/services/email-confirmation.ts
@@ -1,0 +1,129 @@
+import { getDataSource } from '../database/index.js';
+import { EmailConfirmationEntity } from '../database/entities/EmailConfirmation.js';
+import { UserEntity } from '../database/entities/User.js';
+import PgBoss from 'pg-boss';
+import { getDatabaseUrl, getServerConfig } from 'shared-backend/config';
+
+export class EmailConfirmationService {
+  private static generateCode(): string {
+    // Generate a 6-digit numeric code
+    return Math.floor(100000 + Math.random() * 900000).toString();
+  }
+
+  static async createConfirmationCode(userId: string, transaction?: any): Promise<string> {
+    const dataSource = getDataSource();
+    const repository = dataSource.getRepository(EmailConfirmationEntity);
+    
+    // Generate code
+    const code = this.generateCode();
+    
+    // Set expiration to 15 minutes from now
+    const expiresAt = new Date();
+    expiresAt.setMinutes(expiresAt.getMinutes() + 15);
+    
+    // Create confirmation record
+    const confirmation = repository.create({
+      userId,
+      code,
+      expiresAt,
+      used: false
+    });
+    
+    if (transaction) {
+      await transaction.save(confirmation);
+    } else {
+      await repository.save(confirmation);
+    }
+    
+    return code;
+  }
+
+  static async sendConfirmationEmail(
+    userId: string,
+    email: string,
+    username: string,
+    code: string,
+    boss: PgBoss
+  ): Promise<void> {
+    // Send job to email queue
+    const jobData = {
+      userId,
+      email,
+      username,
+      code
+    };
+    
+    await boss.send('send-email-confirmation', jobData, {
+      retryLimit: 3,
+      retryDelay: 60,
+    });
+  }
+
+  static async verifyCode(userId: string, code: string): Promise<boolean> {
+    const dataSource = getDataSource();
+    const confirmationRepo = dataSource.getRepository(EmailConfirmationEntity);
+    const userRepo = dataSource.getRepository(UserEntity);
+    
+    // Find valid confirmation
+    const confirmation = await confirmationRepo.findOne({
+      where: {
+        userId,
+        code,
+        used: false
+      }
+    });
+    
+    if (!confirmation) {
+      return false;
+    }
+    
+    // Check if expired
+    if (new Date() > confirmation.expiresAt) {
+      return false;
+    }
+    
+    // Mark as used and update user
+    await dataSource.transaction(async (manager) => {
+      await manager.update(EmailConfirmationEntity, confirmation.id, { used: true });
+      await manager.update(UserEntity, userId, { emailConfirmed: true });
+    });
+    
+    return true;
+  }
+
+  static async getLatestCodeForTesting(userId: string): Promise<string | null> {
+    const serverConfig = getServerConfig();
+    if (!serverConfig.isDevelopment && !serverConfig.isTest) {
+      throw new Error('This method is only available in development/test environments');
+    }
+    
+    const dataSource = getDataSource();
+    const repository = dataSource.getRepository(EmailConfirmationEntity);
+    
+    const confirmation = await repository.findOne({
+      where: {
+        userId,
+        used: false
+      },
+      order: {
+        createdAt: 'DESC'
+      }
+    });
+    
+    return confirmation?.code || null;
+  }
+
+  static async cleanupExpiredCodes(): Promise<void> {
+    const dataSource = getDataSource();
+    const repository = dataSource.getRepository(EmailConfirmationEntity);
+    
+    await repository
+      .createQueryBuilder()
+      .delete()
+      .where('expiresAt < :now', { now: new Date() })
+      .orWhere('used = true AND createdAt < :oldDate', {
+        oldDate: new Date(Date.now() - 24 * 60 * 60 * 1000) // 24 hours
+      })
+      .execute();
+  }
+}

--- a/packages/backend/src/services/email-confirmation.ts
+++ b/packages/backend/src/services/email-confirmation.ts
@@ -1,6 +1,6 @@
-import { getDataSource } from '../database/index.js';
-import { EmailConfirmationEntity } from '../database/entities/EmailConfirmation.js';
-import { UserEntity } from '../database/entities/User.js';
+import { getDataSource } from '../database/index';
+import { EmailConfirmationEntity } from '../database/entities/EmailConfirmation';
+import { UserEntity } from '../database/entities/User';
 import PgBoss from 'pg-boss';
 import { getDatabaseUrl, getServerConfig } from 'shared-backend/config';
 

--- a/packages/frontend/src/components/AuthModal.tsx
+++ b/packages/frontend/src/components/AuthModal.tsx
@@ -2,46 +2,66 @@ import { useState, useEffect } from 'react'
 import Modal from './Modal'
 import { useAuth } from '../hooks/useAuth'
 
-type AuthMode = 'signup' | 'login'
+type AuthMode = 'signup' | 'login' | 'confirm'
 
 interface AuthModalProps {
   isOpen: boolean
   onClose: () => void
   initialMode?: AuthMode
+  userId?: string
 }
 
 interface FormData {
   email: string
+  username?: string
   password: string
   confirmPassword?: string
+  confirmationCode?: string
 }
 
-const AuthModal = ({ isOpen, onClose, initialMode = 'signup' }: AuthModalProps) => {
-  const { login, signup } = useAuth()
+const AuthModal = ({ isOpen, onClose, initialMode = 'signup', userId }: AuthModalProps) => {
+  const { login, signup, confirmEmail, resendConfirmation, user } = useAuth()
   const [mode, setMode] = useState<AuthMode>(initialMode)
   const [formData, setFormData] = useState<FormData>({
     email: '',
+    username: '',
     password: '',
-    confirmPassword: ''
+    confirmPassword: '',
+    confirmationCode: ''
   })
   const [isLoading, setIsLoading] = useState(false)
   const [errors, setErrors] = useState<Record<string, string>>({})
+  const [confirmationUserId, setConfirmationUserId] = useState<string>(userId || '')
+  const [successMessage, setSuccessMessage] = useState('')
 
   // Update mode when initialMode changes
   useEffect(() => {
     if (isOpen) {
       setMode(initialMode)
+      if (userId) {
+        setConfirmationUserId(userId)
+      }
     }
-  }, [initialMode, isOpen])
+  }, [initialMode, isOpen, userId])
+
+  // Auto-show confirmation if user is not confirmed
+  useEffect(() => {
+    if (isOpen && user && !user.emailConfirmed) {
+      setMode('confirm')
+      setConfirmationUserId(user.id)
+    }
+  }, [isOpen, user])
 
   // Reset form when modal closes or mode changes
   const resetForm = () => {
-    setFormData({ email: '', password: '', confirmPassword: '' })
+    setFormData({ email: '', username: '', password: '', confirmPassword: '', confirmationCode: '' })
     setErrors({})
     setIsLoading(false)
+    setSuccessMessage('')
   }
 
   const handleModeToggle = () => {
+    if (mode === 'confirm') return // Can't toggle away from confirm mode
     setMode(mode === 'signup' ? 'login' : 'signup')
     resetForm()
   }
@@ -56,23 +76,37 @@ const AuthModal = ({ isOpen, onClose, initialMode = 'signup' }: AuthModalProps) 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {}
 
-    if (!formData.email) {
-      newErrors.email = 'Email is required'
-    } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
-      newErrors.email = 'Please enter a valid email address'
-    }
+    if (mode === 'confirm') {
+      if (!formData.confirmationCode) {
+        newErrors.confirmationCode = 'Confirmation code is required'
+      } else if (formData.confirmationCode.length !== 6) {
+        newErrors.confirmationCode = 'Code must be 6 digits'
+      }
+    } else {
+      if (!formData.email) {
+        newErrors.email = 'Email is required'
+      } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
+        newErrors.email = 'Please enter a valid email address'
+      }
 
-    if (!formData.password) {
-      newErrors.password = 'Password is required'
-    } else if (formData.password.length < 8) {
-      newErrors.password = 'Password must be at least 8 characters long'
-    }
+      if (!formData.password) {
+        newErrors.password = 'Password is required'
+      } else if (formData.password.length < 8) {
+        newErrors.password = 'Password must be at least 8 characters long'
+      }
 
-    if (mode === 'signup') {
-      if (!formData.confirmPassword) {
-        newErrors.confirmPassword = 'Please confirm your password'
-      } else if (formData.password !== formData.confirmPassword) {
-        newErrors.confirmPassword = 'Passwords do not match'
+      if (mode === 'signup') {
+        if (!formData.username) {
+          newErrors.username = 'Username is required'
+        } else if (formData.username.length < 3) {
+          newErrors.username = 'Username must be at least 3 characters long'
+        }
+
+        if (!formData.confirmPassword) {
+          newErrors.confirmPassword = 'Please confirm your password'
+        } else if (formData.password !== formData.confirmPassword) {
+          newErrors.confirmPassword = 'Passwords do not match'
+        }
       }
     }
 
@@ -88,27 +122,66 @@ const AuthModal = ({ isOpen, onClose, initialMode = 'signup' }: AuthModalProps) 
     setIsLoading(true)
     
     try {
-      const response = mode === 'signup' 
-        ? await signup(formData.email, formData.password)
-        : await login(formData.email, formData.password)
-
-      if (response.success) {
-        onClose()
-        resetForm()
+      if (mode === 'confirm') {
+        const response = await confirmEmail(confirmationUserId, formData.confirmationCode!)
+        if (response.success) {
+          onClose()
+          resetForm()
+        } else {
+          setErrors({ general: response.message || 'Invalid or expired code' })
+        }
       } else {
-        setErrors({ general: response.message || `${mode} failed. Please try again.` })
+        const response = mode === 'signup' 
+          ? await signup(formData.email, formData.username!, formData.password)
+          : await login(formData.email, formData.password)
+
+        if (response.success) {
+          if (response.requiresEmailConfirmation) {
+            // Switch to confirmation mode
+            setMode('confirm')
+            setConfirmationUserId(response.userId || '')
+            setFormData(prev => ({ ...prev, confirmationCode: '' }))
+            setErrors({})
+          } else {
+            onClose()
+            resetForm()
+          }
+        } else {
+          setErrors({ general: response.message || `${mode} failed. Please try again.` })
+        }
       }
     } catch (error) {
       console.error(`${mode} error:`, error)
       setErrors({ 
-        general: `${mode} failed. Please try again.` 
+        general: `${mode === 'confirm' ? 'Confirmation' : mode} failed. Please try again.` 
       })
     } finally {
       setIsLoading(false)
     }
   }
 
+  const handleResendCode = async () => {
+    setIsLoading(true)
+    try {
+      const response = await resendConfirmation()
+      if (response.success) {
+        setSuccessMessage('A new confirmation code has been sent to your email')
+        setTimeout(() => setSuccessMessage(''), 5000)
+      } else {
+        setErrors({ general: response.message || 'Failed to resend code' })
+      }
+    } catch (error) {
+      setErrors({ general: 'Failed to resend code. Please try again.' })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   const handleClose = () => {
+    // Don't allow closing if email confirmation is required
+    if (mode === 'confirm' && user && !user.emailConfirmed) {
+      return
+    }
     resetForm()
     onClose()
   }
@@ -123,24 +196,34 @@ const AuthModal = ({ isOpen, onClose, initialMode = 'signup' }: AuthModalProps) 
         <div className="text-center mb-6">
           <div className="flex items-center justify-center mb-4">
             <div className="w-12 h-12 bg-orange-500 rounded-lg flex items-center justify-center">
-              <svg
-                className="w-6 h-6 text-white"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                  clipRule="evenodd"
-                />
-              </svg>
+              {mode === 'confirm' ? (
+                <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+              ) : (
+                <svg
+                  className="w-6 h-6 text-white"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              )}
             </div>
           </div>
           <h2 className="text-2xl font-bold text-white mb-2">
-            {mode === 'signup' ? 'Join Hacker Tracker' : 'Welcome Back'}
+            {mode === 'confirm' ? 'Confirm Your Email' : mode === 'signup' ? 'Join Hacker Tracker' : 'Welcome Back'}
           </h2>
           <p className="text-gray-300">
-            {mode === 'signup' ? 'Start tracking your keywords for free' : 'Sign in to your account'}
+            {mode === 'confirm' 
+              ? 'Enter the 6-digit code sent to your email' 
+              : mode === 'signup' 
+              ? 'Start tracking your keywords for free' 
+              : 'Sign in to your account'}
           </p>
         </div>
 
@@ -151,48 +234,91 @@ const AuthModal = ({ isOpen, onClose, initialMode = 'signup' }: AuthModalProps) 
             </div>
           )}
 
-          <div>
-            <label htmlFor="email" className={labelClass}>Email Address</label>
-            <input
-              type="email"
-              id="email"
-              value={formData.email}
-              onChange={handleInputChange('email')}
-              className={inputClass}
-              placeholder="Enter your email"
-              disabled={isLoading}
-            />
-            {errors.email && <p className={errorClass}>{errors.email}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="password" className={labelClass}>Password</label>
-            <input
-              type="password"
-              id="password"
-              value={formData.password}
-              onChange={handleInputChange('password')}
-              className={inputClass}
-              placeholder="Enter your password"
-              disabled={isLoading}
-            />
-            {errors.password && <p className={errorClass}>{errors.password}</p>}
-          </div>
-
-          {mode === 'signup' && (
-            <div>
-              <label htmlFor="confirmPassword" className={labelClass}>Confirm Password</label>
-              <input
-                type="password"
-                id="confirmPassword"
-                value={formData.confirmPassword || ''}
-                onChange={handleInputChange('confirmPassword')}
-                className={inputClass}
-                placeholder="Confirm your password"
-                disabled={isLoading}
-              />
-              {errors.confirmPassword && <p className={errorClass}>{errors.confirmPassword}</p>}
+          {successMessage && (
+            <div className="bg-green-500/10 border border-green-500/20 text-green-400 px-4 py-3 rounded-lg text-sm">
+              {successMessage}
             </div>
+          )}
+
+          {mode === 'confirm' ? (
+            <div>
+              <label htmlFor="confirmationCode" className={labelClass}>Confirmation Code</label>
+              <input
+                type="text"
+                id="confirmationCode"
+                value={formData.confirmationCode || ''}
+                onChange={handleInputChange('confirmationCode')}
+                className={inputClass}
+                placeholder="Enter 6-digit code"
+                maxLength={6}
+                pattern="[0-9]{6}"
+                disabled={isLoading}
+                autoComplete="off"
+              />
+              {errors.confirmationCode && <p className={errorClass}>{errors.confirmationCode}</p>}
+            </div>
+          ) : (
+            <>
+              <div>
+                <label htmlFor="email" className={labelClass}>Email Address</label>
+                <input
+                  type="email"
+                  id="email"
+                  value={formData.email}
+                  onChange={handleInputChange('email')}
+                  className={inputClass}
+                  placeholder="Enter your email"
+                  disabled={isLoading}
+                />
+                {errors.email && <p className={errorClass}>{errors.email}</p>}
+              </div>
+
+              {mode === 'signup' && (
+                <div>
+                  <label htmlFor="username" className={labelClass}>Username</label>
+                  <input
+                    type="text"
+                    id="username"
+                    value={formData.username || ''}
+                    onChange={handleInputChange('username')}
+                    className={inputClass}
+                    placeholder="Choose a username"
+                    disabled={isLoading}
+                  />
+                  {errors.username && <p className={errorClass}>{errors.username}</p>}
+                </div>
+              )}
+
+              <div>
+                <label htmlFor="password" className={labelClass}>Password</label>
+                <input
+                  type="password"
+                  id="password"
+                  value={formData.password}
+                  onChange={handleInputChange('password')}
+                  className={inputClass}
+                  placeholder="Enter your password"
+                  disabled={isLoading}
+                />
+                {errors.password && <p className={errorClass}>{errors.password}</p>}
+              </div>
+
+              {mode === 'signup' && (
+                <div>
+                  <label htmlFor="confirmPassword" className={labelClass}>Confirm Password</label>
+                  <input
+                    type="password"
+                    id="confirmPassword"
+                    value={formData.confirmPassword || ''}
+                    onChange={handleInputChange('confirmPassword')}
+                    className={inputClass}
+                    placeholder="Confirm your password"
+                    disabled={isLoading}
+                  />
+                  {errors.confirmPassword && <p className={errorClass}>{errors.confirmPassword}</p>}
+                </div>
+              )}
+            </>
           )}
 
           <button
@@ -206,26 +332,40 @@ const AuthModal = ({ isOpen, onClose, initialMode = 'signup' }: AuthModalProps) 
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
-                {mode === 'signup' ? 'Creating Account...' : 'Signing In...'}
+                {mode === 'confirm' ? 'Confirming...' : mode === 'signup' ? 'Creating Account...' : 'Signing In...'}
               </div>
             ) : (
-              mode === 'signup' ? 'Create Account' : 'Sign In'
+              mode === 'confirm' ? 'Confirm Email' : mode === 'signup' ? 'Create Account' : 'Sign In'
             )}
           </button>
         </form>
 
         <div className="mt-6 text-center">
-          <p className="text-gray-400 text-sm">
-            {mode === 'signup' ? 'Already have an account?' : "Don't have an account?"}{' '}
-            <button
-              type="button"
-              onClick={handleModeToggle}
-              className="text-orange-500 hover:text-orange-400 font-medium transition-colors"
-              disabled={isLoading}
-            >
-              {mode === 'signup' ? 'Sign In' : 'Sign Up'}
-            </button>
-          </p>
+          {mode === 'confirm' ? (
+            <p className="text-gray-400 text-sm">
+              Didn't receive the code?{' '}
+              <button
+                type="button"
+                onClick={handleResendCode}
+                className="text-orange-500 hover:text-orange-400 font-medium transition-colors"
+                disabled={isLoading}
+              >
+                Resend Code
+              </button>
+            </p>
+          ) : (
+            <p className="text-gray-400 text-sm">
+              {mode === 'signup' ? 'Already have an account?' : "Don't have an account?"}{' '}
+              <button
+                type="button"
+                onClick={handleModeToggle}
+                className="text-orange-500 hover:text-orange-400 font-medium transition-colors"
+                disabled={isLoading}
+              >
+                {mode === 'signup' ? 'Sign In' : 'Sign Up'}
+              </button>
+            </p>
+          )}
         </div>
       </div>
     </Modal>

--- a/packages/integration-test/src/setup/database.ts
+++ b/packages/integration-test/src/setup/database.ts
@@ -1,6 +1,6 @@
 import { DataSource } from 'typeorm';
 import { DatabaseManager } from 'shared-backend/database';
-import { UserEntity } from 'migrations/src/entities/User.js';
+import { UserEntity } from 'migrations/src/entities/User';
 
 // Create test database manager
 const testDbManager = new DatabaseManager({

--- a/packages/integration-test/tests/auth.test.ts
+++ b/packages/integration-test/tests/auth.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import supertest from "supertest";
 import { DataSource, Repository } from "typeorm";
-import { UserEntity } from "migrations/src/entities/User.js";
+import { UserEntity } from "migrations/src/entities/User";
 import {
   setupTestDatabase,
   cleanupTestDatabase,
-} from "../src/setup/database.js";
-import { createApp } from "backend/src/index.js";
+} from "../src/setup/database";
+import { createApp } from "backend/src/index";
 import bcrypt from "bcrypt";
-import TestAgent from "supertest/lib/agent.js";
+import TestAgent from "supertest/lib/agent";
 
 describe("Authentication Integration Tests", () => {
   let app: any;

--- a/packages/integration-test/tests/user-routes.test.ts
+++ b/packages/integration-test/tests/user-routes.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import supertest from "supertest";
 import { DataSource, Repository } from "typeorm";
-import { UserEntity } from "migrations/src/entities/User.js";
+import { UserEntity } from "migrations/src/entities/User";
 import {
   setupTestDatabase,
   cleanupTestDatabase,
-} from "../src/setup/database.js";
-import { createApp } from "backend/src/index.js";
+} from "../src/setup/database";
+import { createApp } from "backend/src/index";
 import bcrypt from "bcrypt";
-import TestAgent from "supertest/lib/agent.js";
+import TestAgent from "supertest/lib/agent";
 
 describe("User Routes Integration Tests", () => {
   let app: any;

--- a/packages/integration-test/tests/user.test.ts
+++ b/packages/integration-test/tests/user.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { DataSource, Repository } from 'typeorm';
-import { UserEntity } from 'migrations/src/entities/User.js';
-import { setupTestDatabase, cleanupTestDatabase, getTestDataSource } from '../src/setup/database.js';
+import { UserEntity } from 'migrations/src/entities/User';
+import { setupTestDatabase, cleanupTestDatabase, getTestDataSource } from '../src/setup/database';
 
 describe('User Entity Integration Tests', () => {
   let dataSource: DataSource;

--- a/packages/jobs/.eslintrc.cjs
+++ b/packages/jobs/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: { node: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-explicit-any': 'warn',
+  },
+}

--- a/packages/jobs/src/boss.ts
+++ b/packages/jobs/src/boss.ts
@@ -1,5 +1,5 @@
 import PgBoss from 'pg-boss';
-import { getDatabaseConnectionString, jobsConfig } from './config.js';
+import { getDatabaseConnectionString, jobsConfig } from './config';
 
 let bossInstance: PgBoss | null = null;
 

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -1,10 +1,10 @@
-import { startBoss, stopBoss, getBoss } from './boss.js';
-import { registerAllJobs, scheduleAllJobs } from './jobs/index.js';
-import { jobsConfig } from './config.js';
+import { startBoss, stopBoss, getBoss } from './boss';
+import { registerAllJobs, scheduleAllJobs } from './jobs/index';
+import { jobsConfig } from './config';
 
-export * from './boss.js';
-export * from './jobs/index.js';
-export * from './config.js';
+export * from './boss';
+export * from './jobs/index';
+export * from './config';
 
 async function main(): Promise<void> {
   if (!jobsConfig.enabled) {

--- a/packages/jobs/src/jobs/email-confirmation-job.ts
+++ b/packages/jobs/src/jobs/email-confirmation-job.ts
@@ -1,0 +1,70 @@
+import { getBoss } from '../boss.js';
+import { getServerConfig } from 'shared-backend/config';
+
+export const EMAIL_CONFIRMATION_JOB_NAME = 'send-email-confirmation';
+
+export interface EmailConfirmationJobData {
+  userId: string;
+  email: string;
+  username: string;
+  code: string;
+}
+
+export async function emailConfirmationJobHandler(jobs: any[]): Promise<void> {
+  for (const job of jobs) {
+    const data = job.data as EmailConfirmationJobData;
+    
+    console.log('[EmailConfirmationJob] Processing email confirmation for:', data.email);
+    console.log('[EmailConfirmationJob] User ID:', data.userId);
+    console.log('[EmailConfirmationJob] Username:', data.username);
+    
+    const serverConfig = getServerConfig();
+    
+    if (serverConfig.isDevelopment || serverConfig.isTest) {
+      // In development/test, just log the code
+      console.log('[EmailConfirmationJob] DEVELOPMENT MODE - Confirmation code:', data.code);
+      console.log('[EmailConfirmationJob] Email would be sent to:', data.email);
+      
+      // Store code in a way tests can access it
+      if (serverConfig.isTest) {
+        // Store in global for test access
+        (global as any).__lastEmailConfirmationCode = data.code;
+        (global as any).__lastEmailConfirmationUserId = data.userId;
+      }
+    } else {
+      // Production email sending (stub for now)
+      console.log('[EmailConfirmationJob] PRODUCTION MODE - Sending email to:', data.email);
+      // TODO: Implement actual email sending
+      // await sendEmail({
+      //   to: data.email,
+      //   subject: 'Confirm your email',
+      //   body: `Your confirmation code is: ${data.code}`
+      // });
+    }
+    
+    console.log('[EmailConfirmationJob] Completed successfully for:', data.email);
+  }
+}
+
+export async function registerEmailConfirmationJob(): Promise<void> {
+  const boss = await getBoss();
+  
+  // Create the queue if it doesn't exist
+  await boss.createQueue(EMAIL_CONFIRMATION_JOB_NAME);
+  
+  // Register the handler
+  await boss.work(EMAIL_CONFIRMATION_JOB_NAME, emailConfirmationJobHandler);
+  console.log('[Jobs] Registered handler for:', EMAIL_CONFIRMATION_JOB_NAME);
+}
+
+export async function triggerEmailConfirmationJob(data: EmailConfirmationJobData): Promise<string | null> {
+  const boss = await getBoss();
+  
+  const jobId = await boss.send(EMAIL_CONFIRMATION_JOB_NAME, data, {
+    retryLimit: 3,
+    retryDelay: 60,
+  });
+  
+  console.log('[EmailConfirmationJob] Triggered job with ID:', jobId);
+  return jobId;
+}

--- a/packages/jobs/src/jobs/email-confirmation-job.ts
+++ b/packages/jobs/src/jobs/email-confirmation-job.ts
@@ -1,4 +1,4 @@
-import { getBoss } from '../boss.js';
+import { getBoss } from '../boss';
 import { getServerConfig } from 'shared-backend/config';
 
 export const EMAIL_CONFIRMATION_JOB_NAME = 'send-email-confirmation';

--- a/packages/jobs/src/jobs/index.ts
+++ b/packages/jobs/src/jobs/index.ts
@@ -1,12 +1,12 @@
-import { getBoss } from '../boss.js';
+import { getBoss } from '../boss';
 import { 
   PLACEHOLDER_JOB_NAME, 
   placeholderJobHandler, 
   schedulePlaceholderJob 
-} from './placeholder-job.js';
+} from './placeholder-job';
 import {
   registerEmailConfirmationJob
-} from './email-confirmation-job.js';
+} from './email-confirmation-job';
 
 export async function registerAllJobs(): Promise<void> {
   const boss = await getBoss();
@@ -22,5 +22,5 @@ export async function scheduleAllJobs(): Promise<void> {
   console.log('[Jobs] All jobs scheduled');
 }
 
-export * from './placeholder-job.js';
-export * from './email-confirmation-job.js';
+export * from './placeholder-job';
+export * from './email-confirmation-job';

--- a/packages/jobs/src/jobs/index.ts
+++ b/packages/jobs/src/jobs/index.ts
@@ -4,12 +4,17 @@ import {
   placeholderJobHandler, 
   schedulePlaceholderJob 
 } from './placeholder-job.js';
+import {
+  registerEmailConfirmationJob
+} from './email-confirmation-job.js';
 
 export async function registerAllJobs(): Promise<void> {
   const boss = await getBoss();
   
   await boss.work(PLACEHOLDER_JOB_NAME, placeholderJobHandler);
   console.log('[Jobs] Registered handler for:', PLACEHOLDER_JOB_NAME);
+  
+  await registerEmailConfirmationJob();
 }
 
 export async function scheduleAllJobs(): Promise<void> {
@@ -18,3 +23,4 @@ export async function scheduleAllJobs(): Promise<void> {
 }
 
 export * from './placeholder-job.js';
+export * from './email-confirmation-job.js';

--- a/packages/jobs/src/jobs/placeholder-job.ts
+++ b/packages/jobs/src/jobs/placeholder-job.ts
@@ -1,4 +1,4 @@
-import { getBoss } from '../boss.js';
+import { getBoss } from '../boss';
 
 export const PLACEHOLDER_JOB_NAME = 'placeholder-job';
 

--- a/packages/migrations/.eslintrc.cjs
+++ b/packages/migrations/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: { node: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-explicit-any': 'warn',
+  },
+}

--- a/packages/migrations/src/data-source.ts
+++ b/packages/migrations/src/data-source.ts
@@ -1,6 +1,6 @@
 import { createDataSource } from 'shared-backend/database';
-import { UserEntity } from './entities/User.js';
-import { EmailConfirmationEntity } from './entities/EmailConfirmation.js';
+import { UserEntity } from './entities/User';
+import { EmailConfirmationEntity } from './entities/EmailConfirmation';
 
 const AppDataSource = createDataSource({
   entities: [UserEntity, EmailConfirmationEntity],

--- a/packages/migrations/src/data-source.ts
+++ b/packages/migrations/src/data-source.ts
@@ -1,8 +1,9 @@
 import { createDataSource } from 'shared-backend/database';
 import { UserEntity } from './entities/User.js';
+import { EmailConfirmationEntity } from './entities/EmailConfirmation.js';
 
 const AppDataSource = createDataSource({
-  entities: [UserEntity],
+  entities: [UserEntity, EmailConfirmationEntity],
   migrations: ['src/migrations/*.ts'],
   migrationsTableName: 'migrations',
   synchronize: false,

--- a/packages/migrations/src/entities/EmailConfirmation.ts
+++ b/packages/migrations/src/entities/EmailConfirmation.ts
@@ -1,0 +1,37 @@
+import { 
+  Entity, 
+  PrimaryGeneratedColumn, 
+  Column, 
+  CreateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn
+} from 'typeorm';
+import { UserEntity } from './User.js';
+
+@Entity('email_confirmations')
+@Index(['userId', 'code'])
+@Index(['expiresAt'])
+export class EmailConfirmationEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  userId!: string;
+
+  @ManyToOne(() => UserEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user!: UserEntity;
+
+  @Column({ type: 'varchar', length: 6 })
+  code!: string;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt!: Date;
+
+  @Column({ type: 'boolean', default: false })
+  used!: boolean;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/packages/migrations/src/entities/EmailConfirmation.ts
+++ b/packages/migrations/src/entities/EmailConfirmation.ts
@@ -7,7 +7,7 @@ import {
   ManyToOne,
   JoinColumn
 } from 'typeorm';
-import { UserEntity } from './User.js';
+import { UserEntity } from './User';
 
 @Entity('email_confirmations')
 @Index(['userId', 'code'])

--- a/packages/migrations/src/migrations/1755419252320-AddEmailConfirmation.ts
+++ b/packages/migrations/src/migrations/1755419252320-AddEmailConfirmation.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class AddEmailConfirmation1755419252320 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: "email_confirmations",
+                columns: [
+                    {
+                        name: "id",
+                        type: "uuid",
+                        isPrimary: true,
+                        generationStrategy: "uuid",
+                        default: "uuid_generate_v4()"
+                    },
+                    {
+                        name: "userId",
+                        type: "uuid"
+                    },
+                    {
+                        name: "code",
+                        type: "varchar",
+                        length: "6"
+                    },
+                    {
+                        name: "expiresAt",
+                        type: "timestamptz"
+                    },
+                    {
+                        name: "used",
+                        type: "boolean",
+                        default: false
+                    },
+                    {
+                        name: "createdAt",
+                        type: "timestamptz",
+                        default: "CURRENT_TIMESTAMP"
+                    }
+                ],
+                foreignKeys: [
+                    {
+                        columnNames: ["userId"],
+                        referencedColumnNames: ["id"],
+                        referencedTableName: "users",
+                        onDelete: "CASCADE"
+                    }
+                ]
+            }),
+            true
+        );
+
+        await queryRunner.query(
+            `CREATE INDEX "IDX_email_confirmations_userId_code" ON "email_confirmations" ("userId", "code")`
+        );
+
+        await queryRunner.query(
+            `CREATE INDEX "IDX_email_confirmations_expiresAt" ON "email_confirmations" ("expiresAt")`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropIndex("email_confirmations", "IDX_email_confirmations_expiresAt");
+        await queryRunner.dropIndex("email_confirmations", "IDX_email_confirmations_userId_code");
+        await queryRunner.dropTable("email_confirmations");
+    }
+
+}

--- a/packages/shared-backend/.eslintrc.cjs
+++ b/packages/shared-backend/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: { node: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-explicit-any': 'warn',
+  },
+}

--- a/packages/shared-backend/src/database/connection.ts
+++ b/packages/shared-backend/src/database/connection.ts
@@ -1,5 +1,5 @@
 import { DataSource, DataSourceOptions } from 'typeorm';
-import { getDatabaseConfig, getServerConfig } from '../config/index.js';
+import { getDatabaseConfig, getServerConfig } from '../config/index';
 
 export interface CreateDataSourceOptions {
   entities?: any[];

--- a/packages/shared-backend/src/database/manager.ts
+++ b/packages/shared-backend/src/database/manager.ts
@@ -1,5 +1,5 @@
 import { DataSource } from 'typeorm';
-import { createDataSource, CreateDataSourceOptions } from './connection.js';
+import { createDataSource, CreateDataSourceOptions } from './connection';
 
 export class DatabaseManager {
   private dataSource: DataSource | null = null;

--- a/packages/shared-types/.eslintrc.cjs
+++ b/packages/shared-types/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: { node: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-explicit-any': 'warn',
+  },
+}

--- a/packages/shared-types/src/user.ts
+++ b/packages/shared-types/src/user.ts
@@ -27,4 +27,10 @@ export interface LoginRequest {
 export interface AuthResponse {
   user: Omit<User, 'passwordHash'>;
   token: string;
+  requiresEmailConfirmation?: boolean;
+}
+
+export interface EmailConfirmationRequest {
+  userId: string;
+  code: string;
 }

--- a/prompts/250817-0-confirm-email.md
+++ b/prompts/250817-0-confirm-email.md
@@ -1,0 +1,13 @@
+It's time to implement a feature for confirming the user's email address after signup. There is a backend component, frontend component, and jobs component. A database migration may be necessary.
+Task details:
+- Implement a third state in the auth modal, besides signup/login, for entering a confirmation code.
+- After signup, and after logging in to an account that hasn't confirmed their email, show the auth modal in confirmation code state.
+- Implement an unauthorized endpoint for entering an email confirmation code.
+- Trigger sending confirmation email in auth registration endpoint.
+- Do not send the code during the request, instead create a new job (and job type), and handle the actual confirmation email send in the job. With pg-boss, we can create the job with its initial state in the same transaction as the user registration, to avoid sending mail when registration fails (and guaranteeing it's only sent once).
+- In development and CI, there should be a way for tests to either access or generate the confirmation code themselves.
+- In production, a real email will be sent. For this task, please stub the implementation.
+
+This is a big task, so please try to take it one step at a time, and if you get stuck do not attempt to work around your issues with non-idiomatic code.
+
+In the future, a similar system may be reused as an alternate login method, e.g. logging in via email code instead of password. Please keep this in mind, so that we can avoid code duplication and unnecessary work.

--- a/prompts/250817-1-email-sender.md
+++ b/prompts/250817-1-email-sender.md
@@ -1,0 +1,7 @@
+Please research and determine a suitable transactional email service for this project. The purpose will be sending account related emails (confirmation, password reset, etc), as well as tracking emails for notifying the user about their keyword subscriptions. The service should be cheap, and easy to integrate into a typescript project
+
+You may not be able to run the code locally, please don't spend too much time trying to get postgres to work if you can't figure it out. The result of this task should be:
+
+Choice of email provider, with instructions for how to set up an account and provide credentials.
+Low level helper function in packages/shared-backend for sending an email to an address or list of addresses, with arguments for header, body, addresses.
+Convenient way to send HTML emails with fallback text, either via MJML templates or another convenient method.

--- a/prompts/250817-2-setup-cleanup.md
+++ b/prompts/250817-2-setup-cleanup.md
@@ -1,0 +1,3 @@
+Please try to set up and run the environment based on instructions in AGENTS.md. If you are able to run docker containers, you can try the method detailed in the Readme.md as well.
+
+Set up the environment with postgres, run the apps, then get the integration and e2e tests to pass. Make improvements to the setup and test processes where you see easy wins, and update setup instructions to be more clear and concise.

--- a/prompts/250817-3-import-improve.md
+++ b/prompts/250817-3-import-improve.md
@@ -1,0 +1,3 @@
+I noticed that many imports are `.js` file extensions, which is not good. This indicates either a mistake in coding, or an issue in the environment. There should be no file extensions for imports, and modules should be used where possible to maintain a clean codebase. Please review all such usage and fix them.
+
+While doing so, please keep an eye out for simple code organization improvements.


### PR DESCRIPTION
- Implement a third state in the auth modal, besides signup/login, for entering a confirmation code.
- After signup, and after logging in to an account that hasn't confirmed their email, show the auth modal in confirmation code state.
- Implement an unauthorized endpoint for entering an email confirmation code.
- Trigger sending confirmation email in auth registration endpoint.
- Do not send the code during the request, instead create a new job (and job type), and handle the actual confirmation email send in the job. With pg-boss, we can create the job with its initial state in the same transaction as the user registration, to avoid sending mail when registration fails (and guaranteeing it's only sent once).
- In development and CI, there should be a way for tests to either access or generate the confirmation code themselves.
- In production, a real email will be sent. For this task, please stub the implementation.